### PR TITLE
feat(tag-bar): add placeholder tags

### DIFF
--- a/SectionZoomingView.xcodeproj/project.pbxproj
+++ b/SectionZoomingView.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		447B7B412911B65800CE3501 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447B7B402911B65800CE3501 /* SearchBar.swift */; };
 		447B7B452911D33400CE3501 /* Font+UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447B7B442911D33400CE3501 /* Font+UIFont.swift */; };
+		447B7B4B2911DFB400CE3501 /* TagBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447B7B4A2911DFB400CE3501 /* TagBar.swift */; };
+		447B7B4D2911E00300CE3501 /* TopBarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447B7B4C2911E00300CE3501 /* TopBarContainer.swift */; };
 		5E1BE3AF2911929B00F0002C /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1BE3AE2911929B00F0002C /* Currency.swift */; };
 		5E1BE3B1291192F800F0002C /* Price.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1BE3B0291192F800F0002C /* Price.swift */; };
 		5E1BE3B62911932A00F0002C /* TakeoutMenuGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1BE3B52911932A00F0002C /* TakeoutMenuGroup.swift */; };
@@ -66,6 +68,8 @@
 /* Begin PBXFileReference section */
 		447B7B402911B65800CE3501 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		447B7B442911D33400CE3501 /* Font+UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+UIFont.swift"; sourceTree = "<group>"; };
+		447B7B4A2911DFB400CE3501 /* TagBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TagBar.swift; sourceTree = "<group>"; };
+		447B7B4C2911E00300CE3501 /* TopBarContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarContainer.swift; sourceTree = "<group>"; };
 		5E1BE3AE2911929B00F0002C /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		5E1BE3B0291192F800F0002C /* Price.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Price.swift; sourceTree = "<group>"; };
 		5E1BE3B52911932A00F0002C /* TakeoutMenuGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeoutMenuGroup.swift; sourceTree = "<group>"; };
@@ -247,6 +251,8 @@
 				83B16D9825CCAF6A008AE1BA /* MenuParentViewController.swift */,
 				8359400125D6031B007010B1 /* ParentVCDrawerExtension.swift */,
 				447B7B402911B65800CE3501 /* SearchBar.swift */,
+				447B7B4A2911DFB400CE3501 /* TagBar.swift */,
+				447B7B4C2911E00300CE3501 /* TopBarContainer.swift */,
 				83F4F4F225E0A3E20026A0F8 /* Utilities.swift */,
 				832357EC25BC9D0E008295FE /* ZoomableViewController.swift */,
 				8370763E29117454000621FC /* ZoomingMenuViewStructures.swift */,
@@ -405,6 +411,7 @@
 				8370763F29117454000621FC /* ZoomingMenuViewStructures.swift in Sources */,
 				83B16D9925CCAF6A008AE1BA /* MenuParentViewController.swift in Sources */,
 				832357ED25BC9D0E008295FE /* ZoomableViewController.swift in Sources */,
+				447B7B4D2911E00300CE3501 /* TopBarContainer.swift in Sources */,
 				8351CDDE2594569700946150 /* AppDelegate.swift in Sources */,
 				831916A825CE27B100753195 /* CoreMenuView.swift in Sources */,
 				447B7B452911D33400CE3501 /* Font+UIFont.swift in Sources */,
@@ -414,6 +421,7 @@
 				5E1BE3BC2911937700F0002C /* TakeoutMenuItem.swift in Sources */,
 				8359400225D6031B007010B1 /* ParentVCDrawerExtension.swift in Sources */,
 				831916A325CCC3A400753195 /* CGSizeExtensions.swift in Sources */,
+				447B7B4B2911DFB400CE3501 /* TagBar.swift in Sources */,
 				5E1BE3B82911934000F0002C /* Menu.swift in Sources */,
 				8351CDE02594569700946150 /* SceneDelegate.swift in Sources */,
 			);

--- a/SectionZoomingView/ZoomableMenu/MenuParentViewController.swift
+++ b/SectionZoomingView/ZoomableMenu/MenuParentViewController.swift
@@ -30,8 +30,9 @@ class MenuParentViewController: UIViewController, ZoomableViewProvider {
     @IBOutlet weak var backingView: UIView!
     @IBOutlet weak var zoomableTopConstraint: NSLayoutConstraint!
 
-    @IBSegueAction func embedSearchBar(_ coder: NSCoder) -> UIViewController? {
-        return UIHostingController(coder: coder, rootView: SearchBar())
+
+    @IBSegueAction func embedTopContainer(_ coder: NSCoder) -> UIViewController? {
+        return UIHostingController(coder: coder, rootView: TopBarContainer())
     }
 
     func zoomableView(for frame: CGRect) -> SectionedView {

--- a/SectionZoomingView/ZoomableMenu/SectionZoomingView/Base.lproj/ZoomableMenu.storyboard
+++ b/SectionZoomingView/ZoomableMenu/SectionZoomingView/Base.lproj/ZoomableMenu.storyboard
@@ -23,16 +23,16 @@
                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1fo-Ym-58x">
-                                <rect key="frame" x="0.0" y="56" width="414" height="634"/>
+                                <rect key="frame" x="0.0" y="104" width="414" height="586"/>
                                 <connections>
                                     <segue destination="sBX-QR-Bg8" kind="embed" id="RsF-DJ-JoT"/>
                                 </connections>
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Esb-ih-ImM">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="104"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="46t-vg-xYK">
-                                        <rect key="frame" x="8" y="8" width="398" height="40"/>
+                                        <rect key="frame" x="8" y="8" width="398" height="88"/>
                                         <fontDescription key="fontDescription" name="GillSans-SemiBold" family="Gill Sans" pointSize="18"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -46,13 +46,13 @@
                                     <constraint firstAttribute="trailingMargin" secondItem="46t-vg-xYK" secondAttribute="trailing" id="zzV-2g-s8y"/>
                                 </constraints>
                             </view>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="loi-1x-FFc" userLabel="Search Bar Container">
-                                <rect key="frame" x="8" y="0.0" width="398" height="56"/>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="loi-1x-FFc" userLabel="Top Bar Container">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="104"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="56" id="ZEo-al-hKE"/>
+                                    <constraint firstAttribute="height" constant="104" id="Y34-89-gRm"/>
                                 </constraints>
                                 <connections>
-                                    <segue destination="Onf-RN-XIb" kind="embed" destinationCreationSelector="embedSearchBar:" id="K83-D3-3sI"/>
+                                    <segue destination="Onf-RN-XIb" kind="embed" destinationCreationSelector="embedTopContainer:" id="K83-D3-3sI"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XQc-Z3-QcA">
@@ -78,9 +78,9 @@
                             <constraint firstItem="1fo-Ym-58x" firstAttribute="top" secondItem="loi-1x-FFc" secondAttribute="bottom" id="LtY-8A-nBL"/>
                             <constraint firstAttribute="bottom" secondItem="89h-El-dg8" secondAttribute="bottom" id="N7e-WV-jPY"/>
                             <constraint firstItem="1fo-Ym-58x" firstAttribute="leading" secondItem="Jn8-De-MI8" secondAttribute="leading" id="T4w-TF-Ptq"/>
-                            <constraint firstItem="loi-1x-FFc" firstAttribute="leading" secondItem="Jn8-De-MI8" secondAttribute="leading" constant="8" id="XSr-7K-PeO"/>
+                            <constraint firstItem="loi-1x-FFc" firstAttribute="leading" secondItem="Jn8-De-MI8" secondAttribute="leading" id="XSr-7K-PeO"/>
                             <constraint firstItem="Esb-ih-ImM" firstAttribute="leading" secondItem="Jn8-De-MI8" secondAttribute="leading" id="gKe-Q6-LZ7"/>
-                            <constraint firstItem="Jn8-De-MI8" firstAttribute="trailing" secondItem="loi-1x-FFc" secondAttribute="trailing" constant="8" id="gUl-d0-ffo"/>
+                            <constraint firstItem="Jn8-De-MI8" firstAttribute="trailing" secondItem="loi-1x-FFc" secondAttribute="trailing" id="gUl-d0-ffo"/>
                             <constraint firstItem="loi-1x-FFc" firstAttribute="top" secondItem="Jn8-De-MI8" secondAttribute="top" id="k2F-QO-FHq"/>
                             <constraint firstItem="Esb-ih-ImM" firstAttribute="top" secondItem="Jn8-De-MI8" secondAttribute="top" id="kLK-lN-dp8"/>
                             <constraint firstItem="89h-El-dg8" firstAttribute="leading" secondItem="scb-Do-tAF" secondAttribute="leading" id="qDH-Ly-kiB"/>
@@ -109,14 +109,14 @@
             <objects>
                 <viewController id="sBX-QR-Bg8" customClass="ZoomableViewController" customModule="SectionZoomingView" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Sk5-Lv-bjO">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="650"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="652.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yZP-70-OmW">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="784"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" placeholderIntrinsicWidth="414" placeholderIntrinsicHeight="818" translatesAutoresizingMaskIntoConstraints="NO" id="9i3-xf-DWn">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="602"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="604.5"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     </view>
                                 </subviews>

--- a/SectionZoomingView/ZoomableMenu/TagBar.swift
+++ b/SectionZoomingView/ZoomableMenu/TagBar.swift
@@ -1,0 +1,45 @@
+//
+//  TagBar.swift
+//  SectionZoomingView
+//
+//  Created by Ryosuke Onaka on 11/1/22.
+//
+
+import SwiftUI
+
+struct TagBar: View {
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                TagText(title: "Vegetarian")
+                TagText(title: "Gluten free")
+                TagText(title: "Vegan")
+                TagText(title: "Raw")
+                TagText(title: "Dairy")
+            }
+            .padding(1)
+        }
+    }
+}
+
+struct TagText: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .foregroundColor(.black)
+            .font(Font(uiFont: UIFont(name: "BrandonText-Bold", size: 12)!))
+            .padding([.leading, .trailing], 16)
+            .padding([.top, .bottom], 8)
+            .overlay(
+                Capsule(style: .continuous)
+                    .stroke(.gray, lineWidth: 1)
+            )
+    }
+}
+
+struct TagBar_Previews: PreviewProvider {
+    static var previews: some View {
+        TagBar()
+    }
+}

--- a/SectionZoomingView/ZoomableMenu/TopBarContainer.swift
+++ b/SectionZoomingView/ZoomableMenu/TopBarContainer.swift
@@ -1,0 +1,24 @@
+//
+//  TopBarContainer.swift
+//  SectionZoomingView
+//
+//  Created by Ryosuke Onaka on 11/1/22.
+//
+
+import SwiftUI
+
+struct TopBarContainer: View {
+    var body: some View {
+        VStack {
+            SearchBar()
+            TagBar()
+        }
+        .padding([.leading, .trailing], 8)
+    }
+}
+
+struct TopBarContainer_Previews: PreviewProvider {
+    static var previews: some View {
+        TopBarContainer()
+    }
+}


### PR DESCRIPTION
Summary:

replace search bar container with top bar container. top bar container vertically stacks a search bar and a tag bar. both search bar view and tag bar view are place holders. 

converting the tags to buttons, binding them, and highlighting the menu will be done in a separate PR.

![Simulator Screen Shot - iPhone 14 Pro - 2022-11-01 at 16 40 05](https://user-images.githubusercontent.com/85515369/199362468-9249650b-dd85-4c72-830f-fd4d24808002.png)