### PR TITLE
feat(tag-bar): highlight tags in menu

### DIFF
--- a/SectionZoomingView/OfflinePayloads/54Mint11Section123.json
+++ b/SectionZoomingView/OfflinePayloads/54Mint11Section123.json
@@ -48,8 +48,8 @@
                             "description" : "Local mixed greens, radish, fennel, carrots, shallot-mustard vinaigrette",
                             "attributes" : [
                                 "Vegetarian",
-                                "Vegan",
                                 "Gluten Free",
+                                "Vegan",
                             ]
                         },
                         {

--- a/SectionZoomingView/ZoomableMenu/CoreMenuView.swift
+++ b/SectionZoomingView/ZoomableMenu/CoreMenuView.swift
@@ -287,7 +287,8 @@ class PlaceholderMenuView: UIView {
 
 enum EntryViewStyle {
     case normal
-    case highlight
+    case highlightViaSearch
+    case highlightViaTag(_ tag: MenuTag)
 }
 
 enum EntryMagnificationStyle {
@@ -327,8 +328,10 @@ extension EntryView {
                 .forEach { label in
                     label.textColor = UIColor.otk_greenDark
                     label.backgroundColor = UIColor.otk_greenLightest
+                    label.layer.borderWidth = 0
+                    label.layer.borderColor = UIColor.white.cgColor
                 }
-        case .highlight:
+        case .highlightViaSearch:
             backgroundColor = .otk_greenLightest
             layer.borderWidth = 1
             layer.borderColor = UIColor.otk_green.cgColor
@@ -337,8 +340,26 @@ extension EntryView {
                 .compactMap { $0 as? TagLabel }
                 .forEach { label in
                     label.textColor = UIColor.otk_ashDark
-                    label.backgroundColor = UIColor.otk_white
+                    label.backgroundColor = .otk_white
                 }
+        case let .highlightViaTag(tag):
+            backgroundColor = .otk_greenLightest
+            layer.borderWidth = 1
+            layer.borderColor = UIColor.otk_green.cgColor
+            if let tags = tagStackView?.subviews.compactMap({ $0 as? TagLabel }) {
+                tags.forEach { label in
+                    if label.text == tag.rawValue || (tag == .raw && label.text == "Contains raw meat") {
+                        label.textColor = UIColor.otk_greenDark
+                        label.backgroundColor = .otk_white
+                        label.layer.borderWidth = 1
+                        label.layer.borderColor = UIColor.otk_green.cgColor
+                    }
+                    else {
+                        label.textColor = UIColor.otk_ashDark
+                        label.backgroundColor = .otk_white
+                    }
+                }
+            }
         }
     }
 }

--- a/SectionZoomingView/ZoomableMenu/MenuParentViewController.swift
+++ b/SectionZoomingView/ZoomableMenu/MenuParentViewController.swift
@@ -108,7 +108,8 @@ class MenuParentViewController: UIViewController, ZoomableViewProvider {
                 v.bottomAnchor.constraint(equalTo: container.safeAreaLayoutGuide.bottomAnchor),
             ])
         }
-        observeSearchBar()
+
+        observeTopContainerBar()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -143,20 +144,20 @@ class MenuParentViewController: UIViewController, ZoomableViewProvider {
     weak var selectedBadge: UIView?
     var selectedItems = [String]()
 
-    private func observeSearchBar() {
-        guard let searchBarViewModel = searchBarViewModel else {
+    private func observeTopContainerBar() {
+        guard let searchBarViewModel = searchBarViewModel,
+              let tagBarViewModel = tagBarViewModel else {
             return
         }
 
-        searchBarViewModel
-            .$searchQuery
-            .filter { !$0.isEmpty }
-            .sink { [weak self] query in
+        Publishers
+            .CombineLatest(searchBarViewModel.$searchQuery, tagBarViewModel.$tappedTag)
+            .sink { [weak self] query, tag in
                 guard let zoomingView = self?.zoomingView else {
                     return
                 }
 
-                zoomingView.highlight(text: query)
+                zoomingView.highlight(with: query, tag: tag)
             }
             .store(in: &cancellables)
     }

--- a/SectionZoomingView/ZoomableMenu/ZoomingMenuViewStructures.swift
+++ b/SectionZoomingView/ZoomableMenu/ZoomingMenuViewStructures.swift
@@ -45,31 +45,29 @@ struct SectionedView {
         // also need a method for "is zooming"
     }
 
-    @discardableResult
-    func highlight(text: String) -> Bool {
-        guard text.count > 2 else {
-            self.view.subviews
-                .compactMap({ ($0 as? EntryView) ?? $0.subviews.first as? EntryView })
-                .forEach ({ $0.configure(style: .normal) })
-            return false
-        }
-        // would be nice to be able to create plural/singular variant
-        // would be nice to have a dictionary of words that would highlight specific items based
-        // on generic words like
-        //TODO: Chris Brandow  2021-02-10 need to deal with section headers
-        var isAnyHighlighted = false
+    // would be nice to be able to create plural/singular variant
+    // would be nice to have a dictionary of words that would highlight specific items based
+    // on generic words
+    func highlight(with text: String, tag: MenuTag) {
         for entryView in self.view.subviews.compactMap({ ($0 as? EntryView) ?? $0.subviews.first as? EntryView }) {
             entryView.configure(style: .normal)
-            if entryView.item?.name.lowercased().contains(text.lowercased()) == true {
-                entryView.configure(style: .highlight)
-                isAnyHighlighted = true
-            }
-            if entryView.item?.itemDescription?.lowercased().contains(text.lowercased()) == true {
-                entryView.configure(style: .highlight)
-                isAnyHighlighted = true
+            if let item = entryView.item {
+                if text.count > 2,
+                   item.name.lowercased().contains(text.lowercased()) {
+                    entryView.configure(style: .highlightViaSearch)
+                }
+
+                if text.count > 2,
+                   let itemDescription = item.itemDescription,
+                   itemDescription.lowercased().contains(text.lowercased()) {
+                    entryView.configure(style: .highlightViaSearch)
+                }
+
+                if item.attributes.contains(tag.rawValue) {
+                    entryView.configure(style: .highlightViaTag(tag))
+                }
             }
         }
-        return isAnyHighlighted
     }
 
     func setButtons(enabled: Bool) {

--- a/SectionZoomingView/ZoomableMenu/ZoomingMenuViewStructures.swift
+++ b/SectionZoomingView/ZoomableMenu/ZoomingMenuViewStructures.swift
@@ -48,6 +48,7 @@ struct SectionedView {
     // would be nice to be able to create plural/singular variant
     // would be nice to have a dictionary of words that would highlight specific items based
     // on generic words
+    //TODO: Chris Brandow  2021-02-10 need to deal with section headers
     func highlight(with text: String, tag: MenuTag) {
         for entryView in self.view.subviews.compactMap({ ($0 as? EntryView) ?? $0.subviews.first as? EntryView }) {
             entryView.configure(style: .normal)


### PR DESCRIPTION
Summary:
tapping on a tag highlights the tag(s) in the menu.
tapping the same tag removes the highlight
works with search and tags together
search doesn't search the section headers

![Simulator Screen Shot - iPhone 14 Pro - 2022-11-02 at 21 40 26](https://user-images.githubusercontent.com/85515369/199649244-08bfd125-fc6c-457c-b715-b4f8ea173d75.png) ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-02 at 21 40 30](https://user-images.githubusercontent.com/85515369/199649248-577aca12-3a67-4bc9-8d51-3c0e0633e437.png) ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-02 at 21 40 33](https://user-images.githubusercontent.com/85515369/199649258-76d7ef24-62c9-4741-a053-2162756f0bf9.png) ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-02 at 21 40 40](https://user-images.githubusercontent.com/85515369/199649264-a6708b44-4d17-4291-a5e9-d3fb17954f10.png) ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-02 at 21 40 43](https://user-images.githubusercontent.com/85515369/199649271-93b7896c-5147-41c4-aa3d-5f22adde6614.png)
